### PR TITLE
issue-46 gridレイアウトでsp版だと2列になるようにする

### DIFF
--- a/web/src/features/Menu/index.tsx
+++ b/web/src/features/Menu/index.tsx
@@ -75,7 +75,7 @@ export const Menu = ({ menuId, searchConditions }: Props) => {
         <section className={styles.ingredients}>
           <SimpleGrid
             spacing={4}
-            templateColumns='repeat(auto-fill, minmax(200px, 1fr))'
+            templateColumns='repeat(auto-fill, minmax(125px, 1fr))'
           >
             {menu?.ingredients.map((ingredient) => (
               <Flex

--- a/web/src/features/Menus/index.tsx
+++ b/web/src/features/Menus/index.tsx
@@ -104,7 +104,7 @@ export const Menus = ({ searchConditions }: Props) => {
           {menus.length > 0 ? (
             <SimpleGrid
               spacing={4}
-              templateColumns='repeat(auto-fill, minmax(200px, 1fr))'
+              templateColumns='repeat(auto-fill, minmax(125px, 1fr))'
             >
               {menus.map((menu) => (
                 <Link

--- a/web/src/features/Restaurants/index.tsx
+++ b/web/src/features/Restaurants/index.tsx
@@ -33,7 +33,7 @@ const Restaurants = memo(() => {
       <div className={styles.container}>
         <SimpleGrid
           spacing={4}
-          templateColumns='repeat(auto-fill, minmax(200px, 1fr))'
+          templateColumns='repeat(auto-fill, minmax(125px, 1fr))'
         >
           {!isLoading
             ? restaurants.map((restaurant) => (


### PR DESCRIPTION
## 概要
issue: #46 

<!--
issue番号を書きましょう
背景があればそれも併せて書きましょう
-->

## 詳細
レストラン一覧、メニュー一覧、メニュー詳細ページにて、gridレイアウトが１列になっていたためスクロール量が増えて見にくかった。
2列でも閲覧は可能なので2列にするように変更した

<!--
レビュアーに重点的に見て欲しい内容を書きましょう  
レビュアーが疑問に思いそうな部分にコメントしておくと理解しやすいです  
-->

## 動作確認
- レストラン一覧
<img width="376" alt="スクリーンショット 2024-09-05 14 19 57" src="https://github.com/user-attachments/assets/e345fbac-2329-4ffd-8155-49ae0c8b7ed1">

- メニュー一覧
<img width="385" alt="スクリーンショット 2024-09-05 14 19 37" src="https://github.com/user-attachments/assets/5a157196-2738-40d7-9013-4a09b3cdb0cf">

- メニュー詳細
<img width="388" alt="スクリーンショット 2024-09-05 14 19 12" src="https://github.com/user-attachments/assets/75c33553-953b-4467-ab5a-52a4861d01b4">


<!--
修正内容について試したこと、スクリーンショット、インタラクションを伴う場合は GIF などを記載しましょう  
-->

## その他

<!--
ライブラリを導入した場合は比較候補と選定理由を記載してください  
-->

## 参考情報

<!--
参考記事の url などを記載しましょう  
-->
