### PR TITLE
issue-72 レストラン作成ページとメニュー作成ページは分ける

### DIFF
--- a/web/src/app/create-menus/page.tsx
+++ b/web/src/app/create-menus/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { CreateMenus } from '@/features/CreateMenus';
+
+const CreateMenusPage = () => <CreateMenus />;
+
+export default CreateMenusPage;

--- a/web/src/features/CreateMenus/Ingredients/index.tsx
+++ b/web/src/features/CreateMenus/Ingredients/index.tsx
@@ -11,7 +11,7 @@ import {
 } from '@chakra-ui/react';
 import { Control, Controller, FieldErrors } from 'react-hook-form';
 import useSWR from 'swr';
-import { FormValues } from '../index.d';
+import { FormValues } from '../../CreateMenus/index.d';
 import styles from '../index.module.scss';
 
 type Props = {

--- a/web/src/features/CreateMenus/Ingredients/index.tsx
+++ b/web/src/features/CreateMenus/Ingredients/index.tsx
@@ -11,7 +11,7 @@ import {
 } from '@chakra-ui/react';
 import { Control, Controller, FieldErrors } from 'react-hook-form';
 import useSWR from 'swr';
-import { FormValues } from '../../CreateMenus/index.d';
+import { FormValues } from '../index.d';
 import styles from '../index.module.scss';
 
 type Props = {

--- a/web/src/features/CreateMenus/Restaurants/index.tsx
+++ b/web/src/features/CreateMenus/Restaurants/index.tsx
@@ -1,0 +1,58 @@
+import { useCustomOptions } from '@/hooks/useOptions';
+import { api } from '@/lib/swagger-client';
+import {
+  Flex,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  Select,
+  Skeleton,
+} from '@chakra-ui/react';
+import { FieldErrors, UseFormRegister } from 'react-hook-form';
+import useSWR from 'swr';
+import { FormValues } from '../index.d';
+import styles from '../index.module.scss';
+
+type Props = {
+  errors: FieldErrors<FormValues>;
+  register: UseFormRegister<FormValues>;
+};
+
+export const Restaurants = ({ errors, register }: Props) => {
+  const { data, isLoading } = useSWR('/restaurants', () =>
+    api.restaurants.restaurantsControllerFindAll()
+  );
+
+  const restaurants = data?.data || [];
+
+  const options = useCustomOptions({
+    items: restaurants,
+    getLabel: (item) => item.name,
+  });
+
+  return (
+    <FormControl isInvalid={!!errors.restaurantId?.message}>
+      <Flex alignItems='center' gap={4} mb={2}>
+        <FormLabel htmlFor='restaurantId' className={styles.label}>
+          レストラン
+        </FormLabel>
+        <span className={styles.required}>必須</span>
+      </Flex>
+      <Skeleton isLoaded={!isLoading}>
+        <Select
+          placeholder='レストランを選択してください'
+          {...register('restaurantId', { required: 'レストランは必須です' })}
+        >
+          {options.map((option) => (
+            <option key={option.key} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </Select>
+      </Skeleton>
+      <FormErrorMessage>
+        {errors.restaurantId?.message?.toString()}
+      </FormErrorMessage>
+    </FormControl>
+  );
+};

--- a/web/src/features/CreateMenus/hooks.ts
+++ b/web/src/features/CreateMenus/hooks.ts
@@ -1,0 +1,74 @@
+import { api } from '@/lib/swagger-client';
+import { useToast } from '@chakra-ui/react';
+import React, { useCallback } from 'react';
+import { UseFieldArrayAppend, UseFormReset } from 'react-hook-form';
+import { FormValues, PreviewType } from './index.d';
+
+type TUseHandlerArgs = {
+  preview: PreviewType;
+  setPreview: (preview: PreviewType) => void;
+  reset: UseFormReset<FormValues>;
+  append: UseFieldArrayAppend<FormValues, 'menus'>;
+};
+
+export const useHandler = ({
+  preview,
+  setPreview,
+  reset,
+  append,
+}: TUseHandlerArgs) => {
+  const toast = useToast();
+
+  const handleSubmit = useCallback(
+    async (values: FormValues) => {
+      try {
+        const { error } = await api.menus.menusControllerCreate({
+          menus: values.menus.map((menu) => ({
+            name: menu.name,
+            // TODO: ファイルアップロードにserverが対応したら修正する
+            pic: '',
+            ingredientIds: menu.ingredientIds,
+          })),
+          restaurantId: values.restaurantId,
+        });
+
+        if (error) throw error;
+
+        reset();
+
+        setPreview({ pic: undefined, 'menus.0.pic': undefined });
+
+        toast({
+          title: 'メニューを作成しました',
+          status: 'success',
+          isClosable: true,
+        });
+      } catch (error) {
+        toast({
+          title: 'メニューを作成できませんでした',
+          status: 'error',
+          isClosable: true,
+        });
+      }
+    },
+    [toast, reset, setPreview]
+  );
+
+  const handleChangeFile = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const { files } = e.target;
+
+      if (!files) return;
+
+      const name = e.target.name;
+
+      setPreview({ ...preview, [name]: URL.createObjectURL(files[0]) });
+    },
+    [preview, setPreview]
+  );
+
+  const handleAddMenu = () =>
+    append([{ name: '', ingredientIds: [], pic: undefined }]);
+
+  return { handleSubmit, handleChangeFile, handleAddMenu };
+};

--- a/web/src/features/CreateMenus/hooks.ts
+++ b/web/src/features/CreateMenus/hooks.ts
@@ -36,7 +36,7 @@ export const useHandler = ({
 
         reset();
 
-        setPreview({ pic: undefined, 'menus.0.pic': undefined });
+        setPreview({ 'menus.0.pic': undefined });
 
         toast({
           title: 'メニューを作成しました',

--- a/web/src/features/CreateMenus/index.d.ts
+++ b/web/src/features/CreateMenus/index.d.ts
@@ -9,6 +9,5 @@ export type FormValues = {
 
 // TODO: メニュー写真の型を動的につける
 export type PreviewType = {
-  pic?: string;
   'menus.0.pic'?: string;
 };

--- a/web/src/features/CreateMenus/index.d.ts
+++ b/web/src/features/CreateMenus/index.d.ts
@@ -1,0 +1,14 @@
+export type FormValues = {
+  restaurantId: string;
+  menus: Array<{
+    name: string;
+    ingredientIds: Array<string>;
+    pic?: FileList;
+  }>;
+};
+
+// TODO: メニュー写真の型を動的につける
+export type PreviewType = {
+  pic?: string;
+  'menus.0.pic'?: string;
+};

--- a/web/src/features/CreateMenus/index.module.scss
+++ b/web/src/features/CreateMenus/index.module.scss
@@ -1,0 +1,18 @@
+.container {
+  padding: 2rem 0;
+
+  .label {
+    font-weight: bold;
+    font-size: 1.125rem;
+    margin: 0;
+  }
+
+  .required {
+    border: 1px solid #e53e3e;
+    border-radius: 4px;
+    color: #e53e3e;
+    font-weight: bold;
+    font-size: 0.75rem;
+    padding: 2px;
+  }
+}

--- a/web/src/features/CreateMenus/index.tsx
+++ b/web/src/features/CreateMenus/index.tsx
@@ -9,12 +9,13 @@ import {
 } from '@chakra-ui/react';
 import { useState } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
-import Genres from './Genres';
 import { useHandler } from './hooks';
 import { FormValues, PreviewType } from './index.d';
 import styles from './index.module.scss';
+import Ingredients from './Ingredients';
+import { Restaurants } from './Restaurants';
 
-export const CreateRestaurant = () => {
+export const CreateMenus = () => {
   const {
     register,
     handleSubmit,
@@ -24,81 +25,31 @@ export const CreateRestaurant = () => {
   } = useForm<FormValues>({
     mode: 'all',
     defaultValues: {
-      name: '',
-      pic: undefined,
-      genre_id: '',
+      restaurantId: '',
       menus: [{ name: '', ingredientIds: [], pic: undefined }],
     },
   });
 
-  const { fields, append } = useFieldArray({
-    control,
-    name: 'menus',
-  });
+  const { fields, append } = useFieldArray({ control, name: 'menus' });
 
   const [preview, setPreview] = useState<PreviewType>({});
 
-  const { handleSubmit: onSubmit, handleFileChange } = useHandler({
+  const {
+    handleSubmit: onSubmit,
+    handleChangeFile,
+    handleAddMenu,
+  } = useHandler({
     preview,
     setPreview,
     reset,
+    append,
   });
-
-  const handleAddMenu = () =>
-    append([{ name: '', ingredientIds: [], pic: undefined }]);
 
   return (
     <div className={styles.container}>
       <form onSubmit={handleSubmit(onSubmit)}>
         <Flex mb={6}>
-          <FormControl isInvalid={!!errors.name?.message}>
-            <Flex alignItems='center' gap={4} mb={2}>
-              <FormLabel htmlFor='name' className={styles.label}>
-                店名
-              </FormLabel>
-              <span className={styles.required}>必須</span>
-            </Flex>
-            <Input
-              id='name'
-              {...register('name', {
-                required: '店名は必須です',
-              })}
-              type='text'
-            />
-            <FormErrorMessage>
-              {errors.name?.message?.toString()}
-            </FormErrorMessage>
-          </FormControl>
-        </Flex>
-        <Flex mb={6}>
-          <FormControl>
-            <Flex mb={2}>
-              <FormLabel htmlFor='file' className={styles.label}>
-                お店の写真
-              </FormLabel>
-            </Flex>
-            <Input
-              type='file'
-              {...register('pic')}
-              accept='image/*'
-              onChange={handleFileChange}
-            />
-            {preview.pic && (
-              <Image
-                src={preview.pic}
-                alt={preview.pic}
-                style={{
-                  maxWidth: '100%',
-                  height: 'auto',
-                }}
-                width='200'
-                height='200'
-              />
-            )}
-          </FormControl>
-        </Flex>
-        <Flex mb={6}>
-          <Genres errors={errors} register={register} />
+          <Restaurants errors={errors} register={register} />
         </Flex>
         {fields.map((field, index) => (
           <div key={field.id}>
@@ -124,6 +75,9 @@ export const CreateRestaurant = () => {
                 </FormErrorMessage>
               </FormControl>
             </Flex>
+            <Flex mb={6}>
+              <Ingredients errors={errors} control={control} index={index} />
+            </Flex>
             <Flex mb={8}>
               <FormControl>
                 <Flex mb={2}>
@@ -133,7 +87,7 @@ export const CreateRestaurant = () => {
                   type='file'
                   {...register(`menus.${index}.pic`)}
                   accept='image/*'
-                  onChange={handleFileChange}
+                  onChange={handleChangeFile}
                 />
                 {/* @ts-ignore */}
                 {preview[`menus.${index}.pic`] && (
@@ -153,6 +107,7 @@ export const CreateRestaurant = () => {
             </Flex>
           </div>
         ))}
+
         <Button onClick={handleAddMenu}>メニューを追加</Button>
 
         <Flex justifyContent='flex-end'>

--- a/web/src/features/CreateRestaurant/hooks.ts
+++ b/web/src/features/CreateRestaurant/hooks.ts
@@ -16,30 +16,18 @@ export const useHandler = ({ preview, setPreview, reset }: TUseHandlerArgs) => {
   const handleSubmit = useCallback(
     async (values: FormValues) => {
       try {
-        const { data, error } =
-          await api.restaurants.restaurantsControllerCreate({
-            name: values.name,
-            // TODO: ファイルアップロードにserverが対応したら修正する
-            pic: '',
-            genreId: values.genre_id,
-          });
-
-        const { error: menuError } = await api.menus.menusControllerCreate({
-          menus: values.menus.map((menu) => ({
-            name: menu.name,
-            // TODO: ファイルアップロードにserverが対応したら修正する
-            pic: '',
-            ingredientIds: menu.ingredientIds,
-          })),
-          restaurantId: data.id,
+        const { error } = await api.restaurants.restaurantsControllerCreate({
+          name: values.name,
+          // TODO: ファイルアップロードにserverが対応したら修正する
+          pic: '',
+          genreId: values.genre_id,
         });
 
         if (error) throw error;
-        if (menuError) throw menuError;
 
         reset();
 
-        setPreview({ pic: undefined, 'menus.0.pic': undefined });
+        setPreview({ pic: undefined });
 
         toast({
           title: 'レストランを作成しました',

--- a/web/src/features/CreateRestaurant/index.d.ts
+++ b/web/src/features/CreateRestaurant/index.d.ts
@@ -2,15 +2,8 @@ export type FormValues = {
   name: string;
   pic?: FileList;
   genre_id: string;
-  menus: Array<{
-    name: string;
-    ingredientIds: Array<string>;
-    pic?: FileList;
-  }>;
 };
 
-// TODO: メニュー写真の型を動的につける
 export type PreviewType = {
   pic?: string;
-  'menus.0.pic'?: string;
 };

--- a/web/src/features/CreateRestaurant/index.tsx
+++ b/web/src/features/CreateRestaurant/index.tsx
@@ -8,7 +8,7 @@ import {
   Input,
 } from '@chakra-ui/react';
 import { useState } from 'react';
-import { useFieldArray, useForm } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
 import Genres from './Genres';
 import { useHandler } from './hooks';
 import { FormValues, PreviewType } from './index.d';
@@ -19,7 +19,6 @@ export const CreateRestaurant = () => {
     register,
     handleSubmit,
     formState: { errors, isSubmitting, isValid },
-    control,
     reset,
   } = useForm<FormValues>({
     mode: 'all',
@@ -27,13 +26,7 @@ export const CreateRestaurant = () => {
       name: '',
       pic: undefined,
       genre_id: '',
-      menus: [{ name: '', ingredientIds: [], pic: undefined }],
     },
-  });
-
-  const { fields, append } = useFieldArray({
-    control,
-    name: 'menus',
   });
 
   const [preview, setPreview] = useState<PreviewType>({});
@@ -43,9 +36,6 @@ export const CreateRestaurant = () => {
     setPreview,
     reset,
   });
-
-  const handleAddMenu = () =>
-    append([{ name: '', ingredientIds: [], pic: undefined }]);
 
   return (
     <div className={styles.container}>
@@ -100,60 +90,6 @@ export const CreateRestaurant = () => {
         <Flex mb={6}>
           <Genres errors={errors} register={register} />
         </Flex>
-        {fields.map((field, index) => (
-          <div key={field.id}>
-            <Flex mb={6}>
-              <FormControl
-                isInvalid={errors.menus && !!errors.menus[index]?.name?.message}
-              >
-                <Flex alignItems='center' gap={4} mb={2}>
-                  <FormLabel className={styles.label} htmlFor='menu_name'>
-                    メニュー
-                  </FormLabel>
-                  <span className={styles.required}>必須</span>
-                </Flex>
-                <Input
-                  type='text'
-                  {...register(`menus.${index}.name`, {
-                    required: 'メニューは必須です',
-                  })}
-                />
-                <FormErrorMessage>
-                  {errors.menus &&
-                    errors.menus[index]?.name?.message?.toString()}
-                </FormErrorMessage>
-              </FormControl>
-            </Flex>
-            <Flex mb={8}>
-              <FormControl>
-                <Flex mb={2}>
-                  <FormLabel className={styles.label}>写真</FormLabel>
-                </Flex>
-                <Input
-                  type='file'
-                  {...register(`menus.${index}.pic`)}
-                  accept='image/*'
-                  onChange={handleFileChange}
-                />
-                {/* @ts-ignore */}
-                {preview[`menus.${index}.pic`] && (
-                  <Image
-                    // @ts-ignore
-                    src={preview[`menus.${index}.pic`]}
-                    alt='プレビュー画像'
-                    style={{
-                      maxWidth: '100%',
-                      height: 'auto',
-                    }}
-                    width='200'
-                    height='200'
-                  />
-                )}
-              </FormControl>
-            </Flex>
-          </div>
-        ))}
-        <Button onClick={handleAddMenu}>メニューを追加</Button>
 
         <Flex justifyContent='flex-end'>
           <Button

--- a/web/src/lib/$path.ts
+++ b/web/src/lib/$path.ts
@@ -13,6 +13,13 @@ const buildSuffix = (url?: {
 };
 
 export const pagesPath = {
+  create_menus: {
+    $url: (url?: { hash?: string }) => ({
+      pathname: '/create-menus' as const,
+      hash: url?.hash,
+      path: `/create-menus${buildSuffix(url)}`,
+    }),
+  },
   create_restaurant: {
     $url: (url?: { hash?: string }) => ({
       pathname: '/create-restaurant' as const,

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 export const config = {
-  matcher: '/create-restaurant/:path*',
+  matcher: ['/create-restaurant/:path*', '/create-menus/:path*'],
 };
 
 export function middleware(req: NextRequest) {


### PR DESCRIPTION
## 概要
issue: #72 

<!--
issue番号を書きましょう
背景があればそれも併せて書きましょう
-->

## 詳細
レストラン作成ページとメニュー作成ページは別々のページとしました。
メニュー作成ページでは、レストランを選択しその選択したレストランに対してメニューを追加できるようにしました。

<!--
レビュアーに重点的に見て欲しい内容を書きましょう  
レビュアーが疑問に思いそうな部分にコメントしておくと理解しやすいです  
-->

## 動作確認

<!--
修正内容について試したこと、スクリーンショット、インタラクションを伴う場合は GIF などを記載しましょう  
-->

## その他

<!--
ライブラリを導入した場合は比較候補と選定理由を記載してください  
-->

## 参考情報

<!--
参考記事の url などを記載しましょう  
-->
