### PR TITLE
メニュー画面に備考の表示

### DIFF
--- a/web/src/features/Menu/index.tsx
+++ b/web/src/features/Menu/index.tsx
@@ -73,7 +73,7 @@ export const Menu = ({ menuId, searchConditions }: Props) => {
           />
         </Flex>
 
-        {menu?.note.trim() && (
+        {menu?.note?.trim() && (
           <Box
             maxW='30rem'
             mx='auto'


### PR DESCRIPTION
## 概要
issue: 
#195 

## 詳細

・利用者側のメニュー画面にて、メニューに対応した備考を表示するようにする。
・備考は、管理画面で設定されたときのみ表示させるようにする。

## 動作確認

・利用者側画面にて、任意のアレルギー成分を含まないメニューを検索して表示させた後、そのメニューをクリックすると、備考を記載しているメニューに関しては備考が表示され、備考の記載がないメニューに関しては備考が表示されていないことを確認した。
