### PR TITLE
docs: アレルギービジネス市場調査レポートを追加

### DIFF
--- a/docs/allergy-business-landscape.md
+++ b/docs/allergy-business-landscape.md
@@ -1,0 +1,156 @@
+# アレルギービジネス全体マップ — 世界の市場・プレイヤー・収益モデル
+
+> 特定サービスへの応用視点を外し、世界のアレルギー関連ビジネス全般をフラットに俯瞰した市場調査。食物アレルギーに限らず、花粉症・アレルギー性鼻炎・喘息・アトピー/アレルギー性皮膚炎・じんましん等を含むアレルギー全般が対象。
+
+| 項目 | 内容 |
+|---|---|
+| 調査手法 | Web横断調査 + 各主張の敵対的検証(3票制、25ソース → 19主張を検証確認) |
+| 対象領域 | ①診断・検査 / ②治療・医薬 / ③アレルゲン回避製品 / ④対応食品 / ⑤デジタルヘルス / ⑥地域(日本) |
+| 地域 | 米国・欧州・アジア(日本含む)横断 |
+| 作成 | 2026-07-07 |
+
+---
+
+## 市場全体の見取り図
+
+アレルギービジネスは大きく **「医療系(診断・薬・免疫療法)」** と **「生活系(回避製品・食品・アプリ)」** に分かれる。金額の桁が最も大きいのは医療系(特に薬)だが、成長率で目立つのは免疫療法・生物学的製剤・フリーフロム食品。**全人口の約30%が何らかのアレルギーを持つ**とされ、母集団そのものが拡大し続けているのが全領域共通の追い風。
+
+| 領域 | 市場規模(直近) | 将来予測 | CAGR | 収益モデルの型 |
+|---|---|---|---|---|
+| アレルギー治療(全体) | **$24.49B**(2026) | $35.28B(2031) | 7.58% | 医薬品販売(処方/OTC) |
+| ├ 抗ヒスタミン薬 | $17.8B(2024) | $28.4B(2034) | 4.8% | 大衆薬・**ジェネリック8割の薄利** |
+| ├ 喘息 生物学的製剤 | $9.07B(2025) | $17.92B(2031) | **12.27%** | 高単価バイオ医薬(注射) |
+| └ アレルゲン免疫療法(SCIT/SLIT) | $1.9〜2.7B | $3.7〜4.0B(2030-32) | 8.7〜9.5% | 治療プログラム(数年課金) |
+| アレルギー診断・検査 | **$5.6〜6.8B** | $10.8〜13.4B(2031-34) | 9.2〜9.6% | 検査試薬・機器・受託 |
+| アレルゲン回避製品(ブロッカー) | $2.1〜2.3B | $4.5B(2035) | 7.1% | 物販 |
+| ├ 空気清浄機(アレルギー含む全体) | $17.91B(2025) | $36.91B(2035) | 7.5% | 物販 + 消耗品(フィルタ) |
+| フリーフロム食品(米国) | **$30.41B**(2025) | $74.33B(2034) | **10.44%** | 物販・EC・D2C |
+
+> ※ 市場規模は調査会社ごとに定義・基準年が異なり、数値に幅がある(例:診断市場は $5.6B〜$6.8B と出典で揺れる)。桁感とCAGRの傾向を見るのが実務的。
+
+---
+
+## 01. 診断・検査 — 大手診断メーカーの寡占市場
+
+血液検査(特異的IgE)、皮膚プリックテスト、コンポーネント診断が中心。**装置・試薬を売る B2B(病院・検査ラボ向け)** が本流。
+
+- **市場規模:** $5.6B(2024)→ $13.4B(2034予測)、CAGR 9.2%。米国だけで $2.2B(世界の約4割)。
+- **構成比:** 検査手法では **in vivo(皮膚プリック等)が約55%** と依然主流、試薬・消耗品が約60%。アレルゲン種別では**吸入系アレルゲンが最大**($2.8B)。エンドユーザーは**病院ラボが最大**($2.9B)。
+- **主要プレイヤー:** Thermo Fisher Scientific(ImmunoCAP)、Siemens Healthineers、Danaher、bioMérieux、Revvity/EUROIMMUN、Eurofins、Canon/Minaris Medical。**上位5社で約25%**、上位勢で35%超。
+- **成長ドライバー:** アレルギー疾患(鼻炎・喘息・アトピー・食物)の増加、包括的パネル/分子診断の需要、都市化・大気汚染・生活様式の変化。
+- **消費者向けの派生:** Everlywell 等の **D2C 検査キット**(自宅採血 → 郵送 → オンライン結果)。ただし「食物“感受性(sensitivity)”検査」は医学的妥当性への批判もあり要注意領域。
+
+> **収益の型:** 試薬・機器の反復販売(B2B)。参入障壁が高く大手寡占。個人向けは D2C キットのEC/サブスク。
+
+---
+
+## 02. 治療・医薬 — 最も金額が大きく、薬効クラスで収益構造が真逆
+
+### (a) 抗ヒスタミン薬 — 巨大だが薄利のコモディティ
+
+- 市場 **$17.8B(2024)→ $28.4B(2034)**、CAGR 4.8%(成長は緩やか)。
+- **ジェネリックが数量の約80%** を占める **薄利・コモディティ**。第2世代が製品の58%、鼻炎が用途の42%。
+- プレイヤーは J&J、Bayer、Sanofi、GSK、Pfizer 等の大手製薬。世界で**約4億人が鼻炎**。
+- オンライン薬局が最速チャネル(CAGR 8.1%)。
+
+### (b) 生物学的製剤(バイオ) — 高単価・高成長の主戦場
+
+- **喘息バイオ市場 $9.07B(2025)→ $17.92B(2031)、CAGR 12.27%** と高成長。
+- **Anti-IL-4Rα(Dupixent/デュピルマブ が代表)が44.8%** で首位。喘息・アトピー・鼻茸など**適応拡大**が成長源。皮下注射が6割、病院投与が5割。
+- Sanofi/Regeneron、GSK、AstraZeneca、Novartis の寡占。
+- 直近の動き:2025年9月に**経口BTK阻害薬 remibrutinib がじんましんで初のFDA承認**、2025年3月に**omalizumab(Xolair)の交換可能バイオ後続品**が15-30%割引で登場 → バイオも後続品競争フェーズへ。
+
+### (c) アレルゲン免疫療法(SCIT/SLIT) — 「根治」を売る数年課金モデル
+
+- 市場 **$1.9〜2.7B**、CAGR 8.7〜9.5%(治療領域で最速級)。
+- **皮下注射(SCIT)が主流(2024で66%)** だが、**舌下(SLIT:錠剤・ドロップ)が最速成長**。自宅で続けやすく D2C 化しやすい。
+- 適応は**鼻炎が7割**だが、**食物アレルギー免疫療法が最速(CAGR 16.85%)**。
+- 専業最大手 **ALK-Abelló が世界シェア約45%**、次いで Stallergenes Greer、HAL Allergy、Allergy Therapeutics。Regeneron・Sanofi も参入。
+
+> **収益の型:** 抗ヒスタミンは薄利多売の物販、バイオは高単価の反復処方、免疫療法は**数年にわたる治療プログラム課金**。どこを狙うかで事業構造が全く異なる。
+
+---
+
+## 03. アレルゲン回避・除去製品 — 物販+消耗品モデル
+
+- **アレルゲンブロッカー市場 $2.1〜2.3B(2024-25)→ $4.5B(2035)**、CAGR 7.1%。空気清浄機・エアフィルタ・鼻用スプレー・拭き取りシート等。
+- **空気清浄機(全体)は $17.91B(2025)→ $36.91B(2035)**、CAGR 7.5%。花粉0.3μmを捕捉する **HEPA が2035年に約40%** を占める見込み。
+- プレイヤー:Dyson、Honeywell、Blueair(Unilever)、IQAir、Philips、LG、Sharp、Coway、Samsung。**北米が約45%**、アジア太平洋が最速成長。
+- 防ダニ寝具・低アレルゲン化粧品・低アレルゲンペットフードも同カテゴリ。
+
+> **収益の型:** 本体の物販 + **フィルタ等の消耗品リピート**(空気清浄機はこの継続収益が肝)。
+
+---
+
+## 04. アレルギー対応食品(フリーフロム)— EC/D2Cで最速成長する生活系
+
+- **米国フリーフロム食品市場 $30.41B(2025)→ $74.33B(2034)、CAGR 10.44%** と大型かつ高成長。
+- セグメント:乳不使用・グルテンフリー・乳糖不使用ほか。プレイヤーは Danone、General Mills、Hain Celestial、Dr. Schär、Mondelez。
+- ドライバー:**米国だけで8,000万人超がアレルギー**(成人1/3・小児1/4 が季節性/湿疹/食物のいずれか)。加えて医学的必要のない「健康志向」層も購買。
+- **McKinsey は「食物アレルギー層は成長市場だが供給不足(underserved)」**と指摘 → 参入余地。
+
+> **収益の型:** メーカーの物販、専門EC・D2Cブランド、サブスク。生活系で最も分かりやすく消費者から直接課金できる。
+
+---
+
+## 05. デジタルヘルス / D2Cサービス — 検査×治療×遠隔診療の束ね売り
+
+医療と生活の境界で伸びている新しい型。代表例が **Wyndly(米・YC W2021、社員10名)**。
+
+- モデル:**自宅で指先採血の検査 → 個別処方の舌下免疫療法ドロップ → 医師のオンライン診療(ビデオ/電話/チャット)を一気通貫**の D2C 定期サービス。
+- ポジショニング:「薬やスプレーで症状を抑える」のではなく **アレルギーの“根本原因”に免疫療法でアプローチ**。
+- 対象市場を**米国6,000万人**と試算。ただし**保険適用の診療はコロラド・カリフォルニア・フロリダの3州に規制で限定**(=遠隔医療の州別ライセンス障壁が実在)。
+- 隣接:症状記録アプリ、**花粉予報アプリ**(ALK-Abelló の Klarify/pollen app 等)、成分スキャンアプリ。
+
+> **収益の型:** 検査+薬+診療を束ねた**サブスク/定期課金**。免疫療法(数年継続)と相性が良く、LTV が高い。規制(遠隔医療の州/国別ライセンス)が最大の参入障壁。
+
+---
+
+## 06. 日本市場 — 花粉症が構造的な巨大ドライバー
+
+- **国民の半数超が花粉症(主にスギ)。** 16歳以下の花粉症疑いは **32.7%(2014)→ 47.4%(2024)** へ急増 = 市場が拡大中。
+- ピーク期の**労働生産性損失は1日あたり約2,320億円(約15億ドル)** — 健康問題であると同時に経済問題。
+- スギ花粉問題は**戦後の造林政策に根ざした構造的なもの**で一過性ではない → **長期需要が続く**。
+- 政府は**30年でスギ花粉を半減**する目標を掲げ、データ駆動の精密林業とデジタル技術を活用 = **政策主導でアレルゲン低減・デジタル解決策への需要**が生まれる。
+- アジア太平洋は**多くの領域で最速成長地域**(免疫療法 CAGR 15.21%、喘息バイオ 14.12%、診断 10.4% 等)で、日本を含むアジアは伸びしろが大きい。
+
+---
+
+## まとめ — 収益モデルの型で見た全体像
+
+| 収益モデル | 該当領域 | 特徴 |
+|---|---|---|
+| **B2B 反復販売** | 診断試薬・機器 | 大手寡占・参入障壁高・安定 |
+| **薄利多売の物販** | 抗ヒスタミン薬 | 巨大だがジェネリックで低マージン |
+| **高単価の反復処方** | 生物学的製剤 | 最高成長・適応拡大が鍵・後続品競争へ |
+| **数年課金の治療プログラム** | 免疫療法(SCIT/SLIT) | 「根治」を売る・LTV高・SLITでD2C化 |
+| **物販 + 消耗品リピート** | 空気清浄機・回避製品 | フィルタ継続収益が肝 |
+| **物販・EC・D2C** | フリーフロム食品 | 生活系で最速・消費者直接課金・供給不足 |
+| **束ね売りのサブスク** | デジタルヘルス(Wyndly型) | 検査+薬+診療を統合・規制が障壁 |
+
+**共通の成長ドライバー:** ①アレルギー有病率の上昇(全人口の約30%、遺伝要因も大)、②生物学的製剤・免疫療法など高単価治療の適応拡大、③消費者の意識向上とD2C/EC化、④アジア太平洋(日本含む)の高成長。
+
+---
+
+## 出典(検証済み)
+
+| 領域 | ソース |
+|---|---|
+| アレルギー治療 市場 | [Mordor Intelligence](https://www.mordorintelligence.com/industry-reports/allergy-treatment-market) |
+| 診断 市場 | [GMInsights](https://www.gminsights.com/industry-analysis/allergy-diagnostics-market) / [MarketsandMarkets](https://www.marketsandmarkets.com/Market-Reports/allergy-diagnostics-market-232871701.html) |
+| 免疫療法 市場 | [Grand View Research](https://www.grandviewresearch.com/industry-analysis/allergy-immunotherapy-market) / [Mordor](https://www.mordorintelligence.com/industry-reports/allergy-immunotherapy-market) / [SNS Insider](https://www.globenewswire.com/news-release/2025/09/16/3150679/0/en/Allergy-Immunotherapy-Market-Size-to-Reach-USD-4-01-Billion-by-2032-as-Sublingual-Immunotherapy-Gains-Momentum-and-Reduces-Long-Term-Healthcare-Cost-SNS-Insider.html) |
+| 喘息バイオ 市場 | [Mordor Intelligence](https://www.mordorintelligence.com/industry-reports/asthma-biologics-market) |
+| 抗ヒスタミン薬 市場 | [Emergen Research](https://www.emergenresearch.com/industry-report/antihistamine-drugs-market) |
+| アレルゲンブロッカー 市場 | [WiseGuy Reports](https://www.wiseguyreports.com/reports/allergen-blocker-market) |
+| 空気清浄機 市場 | [Research Nester](https://www.researchnester.com/reports/air-purifier-market/6260) |
+| フリーフロム食品(米) | [GlobeNewswire](https://www.globenewswire.com/news-release/2026/04/28/3282951/28124/en/United-States-Free-From-Food-Market-Report-2026-2034-Rising-Allergy-Awareness-and-Strong-Demand-for-Gluten-Free-Dairy-Free-and-Clean-Label-Products.html) / [McKinsey](https://www.mckinsey.com/industries/consumer-packaged-goods/our-insights/consumers-with-food-allergies-a-growing-market-remains-underserved) |
+| D2C デジタルヘルス | [Wyndly (Y Combinator)](https://www.ycombinator.com/companies/wyndly) |
+| 花粉アプリ | [ALK-Abelló](https://ir.alk.net/news-releases/news-release-details/pollen-season-kicks-award-winning-pollen-app) |
+| D2C検査キット | [Everlywell](https://www.everlywell.com/products/food-sensitivity/) |
+| 検査試薬 | [Thermo Fisher / ImmunoCAP](https://www.thermofisher.com/phadia/jp/ja/our-solutions/immunocap-allergy-solutions/view-allergy.html) |
+| 日本の花粉症 | [World Economic Forum](https://www.weforum.org/stories/2026/03/japan-seasonal-allergies/) |
+| 日本 皮膚科M&A参考 | [AInvest(Shionogi/Torii)](https://www.ainvest.com/news/shionogi-1-1-billion-torii-acquisition-strategic-play-growth-renal-dermatology-markets-2505/) |
+
+---
+
+<sub>本レポートは Web 横断調査(25ソース)と各主張の3票制敵対的検証(19主張を確認)に基づく。市場規模・CAGR は調査会社により定義・基準年が異なり数値に幅がある(桁感と傾向を重視)。一部の消費者向け「食物感受性検査」は医学的妥当性に議論があり、括弧付きで注記。数値は調査時点(2026年前半)のもの。統合ステップはAPI接続断で自動生成に失敗したため、検証済みデータから手動で統合した。</sub>

--- a/docs/allergy-market-research.md
+++ b/docs/allergy-market-research.md
@@ -1,0 +1,208 @@
+# 海外のアレルギー関連サービスと、そのビジネスモデル
+
+> 日本以外で「収益を上げている」アレルギー関連の事業を4領域で調査し、ohgetsu(アレルギー対応レストラン検索)が日本で取り入れられる勝ち筋を整理したレポート。
+
+| 項目 | 内容 |
+|---|---|
+| 調査手法 | Web横断調査 + 各主張の敵対的検証(25ソース・83主張抽出 → 25主張を検証し全て確認、棄却0) |
+| 対象領域 | ①外食検索 / ②食品EC・D2C / ③医療・検査 / ④スキャン・成分API |
+| 作成 | 2026-07-06 |
+
+---
+
+## 要旨 — 儲かっているのは「検索サービスそのもの」より“食品”と“成分データ”
+
+4領域を調べた結論はシンプルです。ohgetsuのような **レストラン検索アプリ単体で大きく稼いでいる企業は世界的にも見当たりません**。米最大手の **AllergyEats** ですら単独では買収され、いまは消滅しました。一方で、明確に収益化に成功しているのは次の3タイプです。
+
+- **会員制の食品EC(Thrive Market)** — 年会費モデルで **年商700億円超・黒字化**。アレルギー/ダイエット対応を「検索軸」にした食のD2C。
+- **成分スキャンアプリ(Yuka)** — 広告ゼロ・サブスクのみで **ほぼ自己資金経営のまま数億円規模の売上**。
+- **成分・アレルゲン判定API(Edamam)** — 開発者向け **SaaS(月 $14〜$299)**。検索アプリの「裏側」を売る。
+
+逆に、**医薬(経口免疫療法 / OIT)は巨額の資本が必要で、ネスレでさえ撤退**した領域です。ohgetsuの現実的な勝ち筋は「検索を入口に、食品ECか成分データ提供へ横展開する」ことにあります。
+
+---
+
+## 01. 外食・レストラン検索 — 検索は「集客手段」であって「収益源」ではない
+
+この領域は ohgetsu と最も近い。しかし調査の最大の学びは、**純粋な検索アプリは単独では収益化が難しい**という点です。
+
+### AllergyEats(米国・2010年創業)— B2B2C フリーミアム
+
+消費者向けは無料。Yelp型の **クラウドソース評価**(「どれだけアレルギー対応してくれたか」を3問で採点)+ OpenTable予約連携。収益は **飲食店が払う有料掲載枠**(バナー広告ではない)。全米3,000万人のアレルギー人口が対象。創業者 Paul Antico は3人の子どもが食物アレルギー。
+
+| 指標 | 値 |
+|---|---|
+| 掲載レストラン数 | 850,000+ |
+| ステータス | 2022年11月に Sirved が買収 → 本体統合で消滅 |
+| 売上・取得額 | 非開示 |
+
+> **ohgetsuへの示唆:** モデルは ohgetsu とほぼ同じ。だが13年運営しても単独EXITできず、買収後は本体に統合され消滅。**「店舗有料掲載」だけでは天井が低い**ことの実例。年間ランキング(全米で最もアレルギー対応が良い10チェーン)を **PR資産** にした点は真似る価値あり。
+
+### OpenTable / Resy — 店舗向け SaaS / 従量課金(隣接モデル)
+
+アレルギー専業ではないが「予約」で店舗課金する隣接モデル。
+
+- **OpenTable**: 1予約あたり課金(月400席規模で約 $800〜1,600)。Booking Holdings 傘下、3,000万人。
+- **Resy**: 定額SaaS(月 $349〜$499)。American Express 傘下、1,000万人。
+
+> **ohgetsuへの示唆:** 検索の先に **「アレルギー配慮予約」** を差し込めれば、店舗から予約手数料/定額が取れる。予約という具体的な取引が発生して初めて店舗は継続課金する。
+
+### 【日本の競合】Allergy Connect(アレルギーコネクト / 運営:fuseful)
+
+2023年8月にほぼ同じコンセプトで登場。マップ・店名・アレルゲン別に検索でき、2024年2月時点で口コミ経由の **約800ユーザー**。クラウドソース型で「店に直接確認を」と注意書き。**マネタイズは未確立(無料アプリ)**。
+
+→ 日本の外食検索セグメントはまだ「収益前」の空白地帯で、先行者利益を取りに行ける段階。
+
+---
+
+## 02. 食品EC・D2C・サブスク — いちばん儲かっている領域
+
+4領域で最も明確に黒字・大型化しているのがここ。ohgetsuが持つ「アレルギー×食」の文脈と最も相性が良い。
+
+### Thrive Market(米国・2014年創業)— 会員制サブスク EC
+
+Costco型の **年会費モデル(年 $59.95 / 月 $12)** でオーガニック/健康食品を割引販売。**90以上の食事・体質属性(グルテンフリー、Non-GMO 等)で商品を絞り込める** — これはまさに ohgetsu のアレルゲン絞り込みと同じUX。
+
+| 指標 | 値 |
+|---|---|
+| 年商(2025/3) | $700M+ |
+| 有料会員数 | 1.6M+ |
+| 収益性 | 初の通期黒字を達成(2024) |
+| 累計調達額 | $241M+(Series B $111M を含む) |
+
+> **ohgetsuへの示唆:** **「体質・アレルギーで絞り込む → 買える」** が年商700億円の黒字事業になる、という最有力の証明。検索で終わらず **会員課金 + 物販** へ橋渡しする設計が鍵。
+
+### Partake Foods(米国・2016年創業)— アレルゲンフリー D2C / CPG
+
+創業者は **娘が複数の食物アレルギーと診断された元コカ・コーラ幹部**(founder-market-fit)。上位9大アレルゲン不使用の焼き菓子を、EC + マス小売で販売。サブスクではなく **物販中心**。
+
+| 指標 | 値 |
+|---|---|
+| 累計調達額 | $19M(Series B $11.5M, 2022年10月) |
+| 取扱店 | 9,000店(Target / Whole Foods / Walmart / Kroger) |
+| 売上成長 | +200%(2020→2021)/ +100%(2021→2022) |
+
+Jay-Z の Marcy Venture Partners、Rihanna、H.E.R. 等の著名投資家が参加。
+
+> **ohgetsuへの示唆:** アレルゲンフリー食品は **ニッチではなくマス小売で棚を取れる** ことの証明。日本なら ohgetsu が **D2Cブランドの立ち上げ/共同開発の入口** になり得る。
+
+---
+
+## 03. 医療・検査・経口免疫療法(OIT)— 市場は巨大、ただし資本集約的
+
+市場規模は魅力的だが、ここは **製薬・大手診断メーカーの土俵**。ohgetsuが直接参入する領域ではなく、「連携先」として理解しておく領域。
+
+| 指標 | 値 |
+|---|---|
+| アレルギー診断市場 | $6.35B(2025)→ $12.0B(2031), CAGR 11.3% |
+| 最速成長地域 | アジア太平洋(CAGR 13.75%) |
+| 米国のアレルギー有病率 | 成人 31.8% / 小児 27.2% |
+
+主要プレイヤーは Thermo Fisher Scientific、Danaher、Siemens Healthineers、BioMérieux 等の大手診断メーカー。
+
+### 【要注意事例】Palforzia(Aimmune Therapeutics)— ピーナッツ OIT 薬
+
+世界初のFDA承認ピーナッツアレルギー治療薬(2020年1月)。**ネスレが約 $2.1B(21億ドル)で買収** したが、患者・医師への普及が想定を下回り、**わずか3年で Stallergenes Greer へ売却(実質撤退)**。売上は予測($1.28B)に遠く及ばず。
+
+| 指標 | 値 |
+|---|---|
+| Aimmune 純損失(2019単年) | -$248.5M |
+| 累積赤字(承認前まで) | -$724.7M |
+| ネスレ買収額 | $2.1B → 3年で撤退 |
+
+> **警告:** 承認まで **数百億円の赤字を垂れ流す資本集約モデル**。ネスレほどの巨人でも収益化できなかった。**ohgetsuが手を出す領域ではない。**
+
+### 【日本にとっての希望】
+
+Aimmune が次に狙った **卵アレルギーは中国・日本に患者が集中**(日本では卵が最多アレルゲン、世界で600万人超)。→ 日本は「食物アレルギー医療」の需要が構造的に大きい。ohgetsuは **薬を作るのではなく、患者データ・受診導線・生活支援でクリニックやメーカーと組む** ポジションが現実的。
+
+---
+
+## 04. スキャンアプリ・成分データ API — 軽量で高収益
+
+設備投資が要らず、ソフトだけで成立する領域。ohgetsuの技術資産(このリポジトリはすでに PDF からアレルゲンを抽出する機能を開発中)と最も地続き。
+
+### Yuka(フランス・2016年創業)— サブスク(広告ゼロ)
+
+食品・化粧品のバーコードを **スキャンして健康影響を採点**。広告もメーカー課金も一切なし、**Premiumサブスクのみ**(商品検索・オフライン・パーソナル通知を課金)。独立性の証明として BS・売上を公開。
+
+| 指標 | 値 |
+|---|---|
+| 累計調達額 | 〜€800K(2019シード1回のみ) |
+| 推定売上(2024, 外部推計) | $7.4M(※2023推計は $20.3M) |
+| 社員数 | 約20名(超少人数経営) |
+
+> **ohgetsuへの示唆:** **ほぼ自己資金・少人数のまま数億円規模** という、スタートアップに最も再現しやすいモデル。「広告に依存せず、ユーザー課金で独立を保つ」姿勢がブランド価値そのもの。
+> ※ $7.4M / $20.3M は外部サイト(GetLatka)の推計値で振れ幅に注意。
+
+### Edamam — 成分・栄養データ API(開発者向け SaaS)
+
+食品データから **70種以上の食事/アレルゲン判定(Peanut Free 等)を自動生成**。**バーコード照合対応(70万UPC / 約90万食品、うち13万は外食チェーン品目)**。
+
+| 指標 | 値 |
+|---|---|
+| 段階課金 | 月 $14(10万コール)〜 $299(500万コール)+ 無制限は個別見積り |
+| 自動生成タグ | 70+(アレルゲン / 食事) |
+| 収録食品数 | 約900,000(うちバーコード70万) |
+
+> **ohgetsuへの示唆:** 検索アプリの「裏側の成分データ」を API として **他社に売る** B2Bモデル。ohgetsuが日本の外食メニュー×アレルゲンのデータを蓄積すれば、同様にAPI提供が可能。
+
+### その他プレイヤー
+
+- **Spoonful**(米・2018創業):低FODMAP等に強い。Precursor Ventures / Operate 出資。
+- **Fig / foodisgood.com**:27以上の食事カテゴリ(Alpha-Gal・GERD・妊娠中対応まで細分化)、50店舗以上で照合。
+
+この領域は競合多数(Yuka・Codecheck・GreenChoice が上位)で、差別化は **「地域データの独占」** が鍵。
+
+---
+
+## 05. 日本市場の前提・規制
+
+- **法定アレルゲン表示制度がある** — 「特定原材料」(卵・乳・小麦・落花生・えび・かに・そば・くるみ・カシューナッツ 等)は **包装加工食品に表示義務**。「義務」+「推奨」の **2層構造** で、データ製品はこの両方をモデル化する必要がある。
+- **制度は変わり続ける** — **カシューナッツは2026年4月1日に義務化**、マカダミアナッツは2024年3月に推奨追加(まつたけは削除)。消費者庁が約3年ごとの全国実態調査で見直すため、**データベースは継続メンテが前提**。
+- **グルテンフリー市場は堅調成長** — 日本の GF 市場は CAGR 4.70%(2025-2030)。ただし大手(Nestlé, Kellogg's, General Mills, Hain Celestial, キユーピー系 Kibun 等)が寡占。2018年に **世界初の「ノングルテン」米粉認証制度** も登場。
+- **「健康ハロー効果」で客層が広い** — 医療的必要がなくても GF = 健康的と捉える層が拡大し、**アレルギー患者を超えた購買層** がある。販路はスーパー / コンビニ / EC。
+
+---
+
+## 06. 結論 — ohgetsuの勝ち筋
+
+**「検索を入口に、食品ECと成分APIへ横展開する」**
+
+収益実態と日本応用の両面から、ohgetsuが取るべき優先順位:
+
+| 優先度 | 施策 | 参照モデル | 要点 |
+|---|---|---|---|
+| ◎ 最優先 | **① 会員制の食品EC / D2Cへ橋渡し** | Thrive Market | 「絞り込む」を「絞り込んで買える」まで伸ばす。年会費 or 物販マージン。最も黒字化が実証されたモデル。日本のGF/アレルゲンフリー食品はブランドが弱く共同開発の余地大。 |
+| ◎ 最優先 | **② 成分・アレルゲン判定データを API化** | Edamam | 開発中の PDF/メニューからのアレルゲン抽出を、日本の外食メニュー×特定原材料の独自DBに育て B2B提供。設備不要・高粗利。制度改定対応(2026年カシュー義務化等)が参入障壁=堀になる。 |
+| ○ 検討 | **③ スキャンアプリ + ユーザー課金** | Yuka | 広告に頼らずサブスクで独立を保つ少人数モデル。日本の商品バーコード×特定原材料DBを作れば刺さる。競合多数、差別化は網羅性次第。 |
+| ○ 検討 | **④ 店舗向け「アレルギー配慮予約」課金** | OpenTable / Resy | 検索の先に予約を差し込み店舗から手数料/定額。ただし掲載枠課金だけの AllergyEats は天井が低かった — 予約という取引まで作らないと継続課金しない。 |
+| × 非推奨 | **⑤ 医薬・OIT・診断の自社開発** | Palforzia | 数百億円の赤字に耐える資本集約モデル。ネスレでさえ3年で撤退。作る側でなく、患者導線・生活支援でクリニック/メーカーと組む連携ポジションに徹する。 |
+
+> **ひとことで:** ohgetsuの資産は「アレルギー当事者の信頼」と「アレルゲン×食のデータ」。これを **①買える場(EC)** と **②売れるデータ(API)** に変換するのが、海外の成功事例が示す最短の収益化ルート。
+
+---
+
+## 出典(検証済み)
+
+| # | 内容 | ソース |
+|---|---|---|
+| 1 | Sirved acquires AllergyEats(一次) | [PR Newswire](https://www.prnewswire.com/news-releases/restaurant-discovery-platform-sirved-acquires-allergy-friendly-restaurant-guide-allergyeats-301664166.html) |
+| 2 | AllergyEats 創業者/モデル | [MIT Alumni](https://alum.mit.edu/slice/letting-out-yelp-allergy-sufferers) |
+| 3 | OpenTable vs Resy 料金 | [US Tech Automations](https://ustechautomations.com/resources/blog/automate-opentable-vs-resy-for-restaurants-2026) |
+| 4 | Thrive Market 概況 | [Contrary Research](https://research.contrary.com/company/thrive-market) |
+| 5 | Thrive Market 黒字化 | [Forbes](https://www.forbes.com/sites/dianebrady/2024/01/09/thrive-market-ceo-on-what-it-will-take-to-stay-profitable/) |
+| 6 | Partake Foods Series B | [TechCrunch](https://techcrunch.com/2022/10/04/partake-foods-allergy-friendly-series-b/) / [vegconomist](https://vegconomist.com/food-and-beverage/sweets-snacks/partake-raises-11-5m-allergy-friendly-vegan-snacks/) |
+| 7 | Nestlé × Palforzia 撤退 | [FiercePharma](https://www.fiercepharma.com/pharma/2b-and-3-years-later-nestle-ditches-aimmunes-peanut-allergy-drug-palforzia) |
+| 8 | Aimmune 10-K(財務・一次) | [SEC EDGAR](https://www.sec.gov/Archives/edgar/data/1631650/000156459020007384/aimt-10k_20191231.htm) |
+| 9 | アレルギー診断市場 | [Mordor Intelligence](https://www.mordorintelligence.com/industry-reports/allergy-diagnostics-market) / [Towards Healthcare](https://www.towardshealthcare.com/insights/allergy-diagnostics-and-therapeutics-market) |
+| 10 | Yuka 財務/資金 | [GetLatka](https://getlatka.com/companies/yuka.io) / [Yuka公式(一次)](https://help.yuka.io/l/en/article/zrgtb8f2ka-yuka-financing) |
+| 11 | Edamam API(一次) | [Edamam Developer](https://developer.edamam.com/food-database-api) |
+| 12 | Spoonful / Fig | [Tracxn](https://tracxn.com/d/companies/spoonful/__ALgHUL9nDCgb81vfEJWh4dixjLCMqbghhHEl_jFy2dg) / [foodisgood.com](https://foodisgood.com/) |
+| 13 | 日本のアレルゲン表示制度(一次) | [消費者庁](https://www.caa.go.jp/policies/policy/food_labeling/food_sanitation/allergy/) |
+| 14 | 日本 GF市場 | [Mordor Intelligence](https://www.mordorintelligence.com/industry-reports/japan-gluten-free-foods-beverages-market-industry) |
+| 15 | Allergy Connect(日本の競合) | [Forbes JAPAN](https://forbesjapan.com/articles/detail/68881) |
+
+---
+
+<sub>本レポートは Web 横断調査(25ソース・83主張抽出)と、各主張の敵対的検証(25主張を検証し全て確認、棄却0)に基づく。市場規模・売上の一部は調査会社/外部推計を含み、企業非開示の数値(AllergyEats の売上・買収額等)は「非開示」と明記。Yuka の売上($7.4M/$20.3M)は外部サイトの推計で振れ幅がある。数値は調査時点(2026年前半)のもの。</sub>


### PR DESCRIPTION
## 概要

アレルギー関連ビジネスの市場調査レポート2本を `docs/` に追加します。Web横断調査+各主張の敵対的検証に基づく、市場規模・収益モデル・主要プレイヤーの整理です。

## 追加ドキュメント

| ファイル | 内容 |
|---|---|
| `docs/allergy-market-research.md` | 海外のアレルギー関連サービス調査(4領域)。外食検索/食品D2C/医療・OIT/スキャン・API。ohgetsu への応用視点で勝ち筋を整理 |
| `docs/allergy-business-landscape.md` | アレルギービジネス全般の市場マップ(6領域)。診断・検査/治療・医薬/回避製品/対応食品/デジタルヘルス/日本市場をフラットに俯瞰 |

## 補足

- コードには一切変更なし(ドキュメントのみの追加)。
- 市場規模・CAGR は調査会社により定義・基準年が異なり数値に幅があるため、桁感と傾向を重視。企業非開示の数値や外部推計値はその旨を明記済み。
- 事実・数値は各レポート末尾の出典(一次情報含む)で確認可能。重要な意思決定に用いる際は原典での再確認を推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)