### PR TITLE
docs: standalone初回取得後にrenewalをwebrootへ切り替える手順を追記

### DIFF
--- a/docs/letsencrypt-setup.md
+++ b/docs/letsencrypt-setup.md
@@ -58,6 +58,23 @@ docker start nginx-proxy
 このあと PR をマージし、GitHub Actions の **Deploy Nginx Proxy and DB**（`workflow_dispatch`）を
 実行すると、証明書を読む新しい本番 nginx と certbot（自動更新）コンテナが起動する。
 
+> **重要（standalone → webroot への切り替え）**: 初回取得を `--standalone` で行うと、
+> renewal 設定にも standalone が記録される。しかし更新時は 80 番を本番 nginx が使っているため、
+> standalone のままだと自動更新が 80 番の競合で失敗する。新 nginx デプロイ後に一度だけ、
+> 更新方式を webroot に切り替えておくこと（新 nginx は `/.well-known/acme-challenge` を配信できる）。
+>
+> ```sh
+> # renewal 設定を webroot に切り替える（この1回だけ 80番競合なしで動くよう nginx 稼働中に実行）
+> docker run --rm \
+>   -v letsencrypt:/etc/letsencrypt \
+>   -v certbot-webroot:/var/www/certbot \
+>   certbot/certbot certonly --webroot -w /var/www/certbot \
+>     -d ohgetsu.com --force-renewal --agree-tos
+>
+> # 以後の自動更新が通るか検証
+> docker exec certbot certbot renew --dry-run
+> ```
+
 > 補足: 発行検証がうまくいくか不安な場合は、上記 `certonly` に `--staging` を付けて
 > Let's Encrypt のステージング環境で試すとレート制限を消費せずに確認できる。成功したら
 > `--staging` を外して本番証明書を取得し直す（staging の証明書は `letsencrypt` ボリューム上に


### PR DESCRIPTION
## 概要

#287 で SSL を Let's Encrypt に移行した際、初回証明書取得を `--standalone` で行った。
standalone は renewal 設定にも standalone として記録されるため、**自動更新時に本番 nginx が
掴んでいる 80 番と競合して更新に失敗する**恐れがある（更新が走る有効期限30日前まで顕在化しない）。

新 nginx は `/.well-known/acme-challenge` を配信できるため、renewal 方式を webroot に一度
切り替えておけば競合なく自動更新できる。その手順と `--dry-run` 検証を手順書に追記した。

## 変更内容

- `docs/letsencrypt-setup.md`: standalone → webroot への切り替え手順と自動更新の事前検証を追記

ドキュメントのみの変更。

> 更新方式や certbot の挙動は変わり得るため、実行前に Let's Encrypt / certbot 公式ドキュメントの一次情報で確認すること。

🤖 Generated with [Claude Code](https://claude.com/claude-code)