### PR TITLE
ci(deploy): 全デプロイワークフローで dangling イメージを掃除する

### DIFF
--- a/.github/workflows/deploy-nginx-db.yml
+++ b/.github/workflows/deploy-nginx-db.yml
@@ -126,3 +126,9 @@ jobs:
             else
               echo "ohgetsu-db is already running; leaving it untouched."
             fi
+
+            # Clean up dangling images left behind by "docker pull latest".
+            # Each deploy pulls a new :latest, orphaning the previous one as an
+            # untagged <none> image. Images still referenced by a running
+            # container are never removed by prune, so this is safe.
+            docker image prune -f

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -71,3 +71,7 @@ jobs:
             docker run -d --name ohgetsu-server --network ohgetsu_network \
               -e DATABASE_URL="postgres://${{ secrets.DB_USER }}:${{ secrets.DB_PASSWORD }}@ohgetsu-db:5432/ohgetsu" \
               -p 8080:8080 ${{ env.REGISTRY }}/${{ env.SERVER_IMAGE_NAME }}:latest
+
+            # Clean up the dangling <none> image orphaned by pulling the new
+            # :latest. Images used by a running container are never pruned.
+            docker image prune -f

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -69,3 +69,7 @@ jobs:
             docker rm -f ohgetsu-web || true
             docker run -d --name ohgetsu-web --network ohgetsu_network \
               -p 3000:3000 ${{ env.REGISTRY }}/${{ env.WEB_IMAGE_NAME }}:latest
+
+            # Clean up the dangling <none> image orphaned by pulling the new
+            # :latest. Images used by a running container are never pruned.
+            docker image prune -f


### PR DESCRIPTION
## 概要

各デプロイは `docker pull ...:latest` で新しい latest を取得するため、前回の latest がタグを失って `<none>`（dangling）イメージとしてサーバーに残り続け、デプロイのたびに積み上がっていた。この問題は nginx だけでなく **web・server の全デプロイワークフロー**に共通する（web/server は main への push ごとに走るため、より頻繁に溜まる）。

全対象のコンテナ (再)起動後に `docker image prune -f` を実行して掃除する。

## 変更内容

- `.github/workflows/deploy-nginx-db.yml`
- `.github/workflows/deploy-web.yml`
- `.github/workflows/deploy-server.yml`

いずれも SSH スクリプト末尾に `docker image prune -f` を追加。

## 安全性

- `prune -f`（`-a` なし）は **dangling イメージのみ**削除。タグ付き・使用中イメージは消えない
- 稼働中コンテナが参照するイメージは prune 対象外
- コンテナ起動後に実行するため、サービス影響なし

既にサーバーに溜まっている `<none>` は、次回いずれかのワークフロー実行時にまとめて掃除される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)