### PR TITLE
デプロイ先サーバーでのdocker pull前にdocker loginを追加

### DIFF
--- a/.github/workflows/deploy-nginx-db.yml
+++ b/.github/workflows/deploy-nginx-db.yml
@@ -49,13 +49,19 @@ jobs:
           REGISTRY: ${{ env.REGISTRY }}
           NGINX_IMAGE_NAME: ${{ env.NGINX_IMAGE_NAME }}
           DOMAIN: ohgetsu.com
+          REGISTRY_PULL_USERNAME: ${{ secrets.SAKURA_CLOUD_PULL_USERNAME }}
+          REGISTRY_PULL_PASSWORD: ${{ secrets.SAKURA_CLOUD_PULL_PASSWORD }}
         with:
           host: ${{ secrets.SAKURA_CLOUD_SSH_HOST }}
           username: ${{ secrets.SAKURA_CLOUD_SSH_USERNAME }}
           key: ${{ secrets.SAKURA_CLOUD_SSH_KEY }}
-          envs: REGISTRY,NGINX_IMAGE_NAME,DOMAIN
+          envs: REGISTRY,NGINX_IMAGE_NAME,DOMAIN,REGISTRY_PULL_USERNAME,REGISTRY_PULL_PASSWORD
           script: |
             set -e
+
+            # Log in on the deploy target so the pull below works now that
+            # the registry's public "Pull only" access has been discontinued.
+            echo "${REGISTRY_PULL_PASSWORD}" | docker login ${REGISTRY} -u "${REGISTRY_PULL_USERNAME}" --password-stdin
 
             # Pull the latest nginx image
             docker pull ${REGISTRY}/${NGINX_IMAGE_NAME}:latest

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -60,6 +60,10 @@ jobs:
           username: ${{ secrets.SAKURA_CLOUD_SSH_USERNAME }}
           key: ${{ secrets.SAKURA_CLOUD_SSH_KEY }}
           script: |
+            # Log in on the deploy target so the pull below works now that
+            # the registry's public "Pull only" access has been discontinued.
+            echo "${{ secrets.SAKURA_CLOUD_PULL_PASSWORD }}" | docker login ${{ env.REGISTRY }} -u "${{ secrets.SAKURA_CLOUD_PULL_USERNAME }}" --password-stdin
+
             # Pull the latest images
             docker pull ${{ env.REGISTRY }}/${{ env.SERVER_IMAGE_NAME }}:latest
 

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -59,6 +59,10 @@ jobs:
           username: ${{ secrets.SAKURA_CLOUD_SSH_USERNAME }}
           key: ${{ secrets.SAKURA_CLOUD_SSH_KEY }}
           script: |
+            # Log in on the deploy target so the pull below works now that
+            # the registry's public "Pull only" access has been discontinued.
+            echo "${{ secrets.SAKURA_CLOUD_PULL_PASSWORD }}" | docker login ${{ env.REGISTRY }} -u "${{ secrets.SAKURA_CLOUD_PULL_USERNAME }}" --password-stdin
+
             # Pull the latest images
             docker pull ${{ env.REGISTRY }}/${{ env.WEB_IMAGE_NAME }}:latest
 


### PR DESCRIPTION
## 概要
- さくらインターネットのコンテナレジストリ `ohgetsu.sakuracr.jp` の公開設定「Pullのみ」が2026年8月27日付で廃止され、以後は非公開（認証必須）になる
- GitHub Actionsランナー側の `docker push` は `docker/login-action` で既に認証済みだが、`appleboy/ssh-action` でデプロイ先サーバーに入って実行する `docker pull` には認証がなく、現状は「Pullのみ」公開だから動いている状態
- 非公開化されると全workflowの `docker pull` が失敗し、デプロイが止まるため、事前に対応

## 変更内容
`.github/workflows/deploy-server.yml` / `deploy-web.yml` / `deploy-nginx-db.yml` の3ファイルに、デプロイ先サーバー上での `docker pull` 実行前に `docker login` を追加。Push & Pull権限を持つ専用ユーザー `ohgetsu-user` の認証情報を新規Secretから使用する。

## 必要な事前準備（マージ前後で対応が必要）
1. GitHub Secretsに以下を追加
   - `SAKURA_CLOUD_PULL_USERNAME` = `ohgetsu-user`
   - `SAKURA_CLOUD_PULL_PASSWORD` = さくらコンソール「ユーザ」タブの鉛筆アイコンから再設定した新パスワード
2. マージ後、実際にdeploy workflowが走ってdeploy先での `docker login` → `docker pull` が成功することを確認
3. 確認が取れたら、さくらのコンテナレジストリ公開設定を「非公開」に変更

## Test plan
- [ ] Secrets追加後、mainマージにより `deploy-web.yml`（または該当workflow）が実行され、deploy先での `docker login`・`docker pull` が成功することを確認
- [ ] さくらのレジストリ公開設定を「非公開」に変更後も、再度workflowを実行してデプロイが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)