### PR TITLE
デプロイ先のdocker loginをSAKURA_CLOUD_USERNAME/PASSWORDに統一

### DIFF
--- a/.github/workflows/deploy-nginx-db.yml
+++ b/.github/workflows/deploy-nginx-db.yml
@@ -49,8 +49,8 @@ jobs:
           REGISTRY: ${{ env.REGISTRY }}
           NGINX_IMAGE_NAME: ${{ env.NGINX_IMAGE_NAME }}
           DOMAIN: ohgetsu.com
-          REGISTRY_PULL_USERNAME: ${{ secrets.SAKURA_CLOUD_PULL_USERNAME }}
-          REGISTRY_PULL_PASSWORD: ${{ secrets.SAKURA_CLOUD_PULL_PASSWORD }}
+          REGISTRY_PULL_USERNAME: ${{ secrets.SAKURA_CLOUD_USERNAME }}
+          REGISTRY_PULL_PASSWORD: ${{ secrets.SAKURA_CLOUD_PASSWORD }}
         with:
           host: ${{ secrets.SAKURA_CLOUD_SSH_HOST }}
           username: ${{ secrets.SAKURA_CLOUD_SSH_USERNAME }}

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -62,7 +62,7 @@ jobs:
           script: |
             # Log in on the deploy target so the pull below works now that
             # the registry's public "Pull only" access has been discontinued.
-            echo "${{ secrets.SAKURA_CLOUD_PULL_PASSWORD }}" | docker login ${{ env.REGISTRY }} -u "${{ secrets.SAKURA_CLOUD_PULL_USERNAME }}" --password-stdin
+            echo "${{ secrets.SAKURA_CLOUD_PASSWORD }}" | docker login ${{ env.REGISTRY }} -u "${{ secrets.SAKURA_CLOUD_USERNAME }}" --password-stdin
 
             # Pull the latest images
             docker pull ${{ env.REGISTRY }}/${{ env.SERVER_IMAGE_NAME }}:latest

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -61,7 +61,7 @@ jobs:
           script: |
             # Log in on the deploy target so the pull below works now that
             # the registry's public "Pull only" access has been discontinued.
-            echo "${{ secrets.SAKURA_CLOUD_PULL_PASSWORD }}" | docker login ${{ env.REGISTRY }} -u "${{ secrets.SAKURA_CLOUD_PULL_USERNAME }}" --password-stdin
+            echo "${{ secrets.SAKURA_CLOUD_PASSWORD }}" | docker login ${{ env.REGISTRY }} -u "${{ secrets.SAKURA_CLOUD_USERNAME }}" --password-stdin
 
             # Pull the latest images
             docker pull ${{ env.REGISTRY }}/${{ env.WEB_IMAGE_NAME }}:latest


### PR DESCRIPTION
## 背景
PR #304 でデプロイ先サーバーの `docker pull` 前に `docker login` を追加した際、push用（`SAKURA_CLOUD_USERNAME`/`PASSWORD`）とは別に、pull専用の `SAKURA_CLOUD_PULL_USERNAME`/`SAKURA_CLOUD_PULL_PASSWORD` を新設した。

しかし確認の結果、さくらコンソールに存在するレジストリ用ユーザーは `ohgetsu-user` のみで、`SAKURA_CLOUD_USERNAME`/`PASSWORD` と `SAKURA_CLOUD_PULL_USERNAME`/`PASSWORD` は同一ユーザーを指す重複した値だった。

## 変更内容
3つのdeploy workflow（`deploy-server.yml` / `deploy-web.yml` / `deploy-nginx-db.yml`）のデプロイ先での `docker login` を、`SAKURA_CLOUD_PULL_USERNAME`/`SAKURA_CLOUD_PULL_PASSWORD` から `SAKURA_CLOUD_USERNAME`/`SAKURA_CLOUD_PASSWORD` に変更し、Secretを1系統に統一。

## 必要な後続対応
- マージ後、GitHub Secretsから `SAKURA_CLOUD_PULL_USERNAME` / `SAKURA_CLOUD_PULL_PASSWORD` を削除可能（コード上の参照がなくなるため）

## Test plan
- [ ] マージ後、`Deploy server` / `Deploy web` を実行し、push用ログイン・デプロイ先pull用ログインの両方が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)